### PR TITLE
css refactoring (mainly for mobile layouts)

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html style="background-color: black;">
+<html>
 	<head>
 		<meta charset="UTF-8">
 		<title>HaloDev Games</title>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@
 <html style="background-color: black;">
 	<head>
 		<meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1"/>
+
 		<title>HaloDev Games</title>
 
 		<link rel="icon" href="https://cdn.halodev.games/Favicon.png" type="image/png">

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 
 	<body style="display: flex;	align-items: center; justify-content: center;">
 		<div class="centre">
-			<div class="box">
+			<div class="box" style="margin-bottom: 2em;">
 				<h1>
 					HaloDev Games has shut down
 				</h1>
@@ -55,8 +55,6 @@
 					</li>
 				</ul>
 			</div>
-
-			<div class="empty">	</div>
 
 			<div class="box">
 				<div id="socials" class="grid">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html style="background-color: black;">
+<html>
 	<head>
 		<meta charset="UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -79,6 +79,4 @@
 			</div>
 		</div>
 	</body>
-
-	<img id="background" src="./background.png" style="position: fixed; background-clip: padding-box; height: auto; left: 50%; top: 50%;	min-width: 100%; min-height: 100%; transform: translate(-50%, -50%); width: auto;" draggable="false"></img>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,3 +1,14 @@
+/* background */
+
+body {
+   background-attachment: fixed;
+   background-image: url("/background.png");
+   background-position: center; 
+	background-size: cover;
+}
+
+
+
 /* font */
 
 @font-face {

--- a/style.css
+++ b/style.css
@@ -94,11 +94,6 @@ a.scroll-anchor:focus {
 	position: relative;
 	background-color: #212121;
 	border-radius: 15px;
-	
-}
-
-.empty {
-	padding: 1em;
 }
 
 

--- a/style.css
+++ b/style.css
@@ -102,7 +102,7 @@ a.scroll-anchor:focus {
 /* main sections */
 
 .box {
-	display: flow-root; /* if the display seems fucked up, this may be the line that's causing it ! */
+	display: block;
 	padding: 1em;
 	position: relative;
 	background-color: #212121;

--- a/style.css
+++ b/style.css
@@ -25,16 +25,6 @@ h1 {
 	margin-top: 0;
 }
 
-h2 {
-    font-size: 1.25em;
-    font-weight: bold;
-}
-
-h3 {
-    font-size: 1em;
-    font-weight: bold;
-}
-
 
  
 /* text */
@@ -55,37 +45,6 @@ li::marker {
 	color: #808080;
 }
 
-time {
-	background: hsla(0, 0%, 0%, 0.075);
-	border: 1px solid hsla(0, 0%, 0%, 0.10);
-	border-radius: 4px;
-	padding: 0 0.2em;
-	position: relative;
-}
-
-time .popup {
-	background-color: #e6e6e6;
-	border: 1px solid hsla(0, 0%, 0%, 0.10);
-	border-radius: 4px;
-	bottom: 1.5em;
-	display: none;
-	margin: 0 calc(-1px - 0.2em);
-	padding: 0 0.2em;
-	position: absolute;
-	visibility: hidden;
-}
-
-time:hover .popup {
-	display: inline;
-	visibility: visible;
-	width: max-content;
-}
-
-.corner-border:has(> .button:hover), .corner-border:has(> .large-button:hover), .media-corner-border:has(> a:hover) {
-	scale: 110%;
-	filter: brightness(90%);
-}
-
 a:link:not(.button, .large-button, .footer-item), a:visited:not(.button, .large-button, .footer-item) {
 	color: hsl(197, calc(var(--saturation-factor, 1) * 100%), 47.8%);
 	text-decoration: none;
@@ -93,14 +52,6 @@ a:link:not(.button, .large-button, .footer-item), a:visited:not(.button, .large-
 
 a:hover:not(.button, .large-button, .footer-item) {
 	text-decoration: underline;
-}
-
-
-
-/* images */
-
-.circle-border {
-	border-radius: 100%;
 }
 
 
@@ -135,7 +86,6 @@ a.scroll-anchor:focus {
 	width: 75%;
 	position: relative;
 	z-index: 2;
-	
 }
 
 .box {
@@ -145,10 +95,6 @@ a.scroll-anchor:focus {
 	background-color: #212121;
 	border-radius: 15px;
 	
-}
-
-hr {
-	width: 100%;
 }
 
 .empty {
@@ -166,32 +112,7 @@ hr {
 
 
 
-/* main sections */
-
-section {
-	display: -webkit-flex;
-	display: flex;
-}
-
-article {
-	display: flex;
-	-webkit-flex: 3;
-	-ms-flex: 3;
-	flex: 3;
-	flex-direction: column;
-	gap: 1em;
-	padding: 1em;
-}
-
-
 /* groups */
-
-.list {
-	column-gap: 0.2em;
-	display: grid;
-	grid-template-columns: repeat(1, minmax(0, 1fr));
-	row-gap: 0.2em;
-}
 
 .grid {
 	column-gap: 1em;
@@ -226,31 +147,7 @@ article {
 
 /* media */
 
-img, video {
-	width: 100%;
-}
-
-.media-corner-border:has(.thumbnail) {
-	height: auto;
-	float: right;
-	width: auto;
-}
-
-.thumbnail {
-	position: relative;
-	width: 10em;
-}
-
-a img {
-	text-decoration: none;
-}
-
-.media-corner-border:has(.youtube-video) {
-	aspect-ratio: 16 / 9;
-}
-
-.youtube-video {
-	height: 100%;
+img {
 	width: 100%;
 }
 
@@ -264,11 +161,6 @@ a img {
 	width: auto;
 }
 
-.inline-button-emoji {
-	float: none !important;
-	height: 1.25em !important;
-}
-
 
 
 /* responsive web design */
@@ -279,32 +171,31 @@ a img {
 
 @media only screen and (max-width: 750px) {
 	.desktop {
-	display: none;
+	    display: none;
 	}
 
 	.mobile {
-	display: block;
-
+	    display: block;
 	}
 
 	ul {
-	padding-left: 1.25em;
+	    padding-left: 1.25em;
 	}
 
 	.grid {
-	grid-template-columns: repeat(1, minmax(0, 1fr));
+	    grid-template-columns: repeat(1, minmax(0, 1fr));
 	}
 
 	.thumbnail {
-	width: 5em !important
+	    width: 5em !important
 	}
 
 	.centre, article {
-	padding: 0 !important;
+	    padding: 0 !important;
 	}
 
 	section {
-	-webkit-flex-direction: column;
-	flex-direction: column;
+        -webkit-flex-direction: column;
+        flex-direction: column;
 	}
 }

--- a/style.css
+++ b/style.css
@@ -88,14 +88,6 @@ a.scroll-anchor:focus {
 	z-index: 2;
 }
 
-.box {
-	display: flow-root; /* if the display seems fucked up, this may be the line that's causing it ! */
-	padding: 1em;
-	position: relative;
-	background-color: #212121;
-	border-radius: 15px;
-}
-
 
 
 /* borders */
@@ -103,6 +95,18 @@ a.scroll-anchor:focus {
 .border {
 	--border-colour: #424242;
 	outline: 0.25em solid var(--border-colour);
+}
+
+
+
+/* main sections */
+
+.box {
+	display: flow-root; /* if the display seems fucked up, this may be the line that's causing it ! */
+	padding: 1em;
+	position: relative;
+	background-color: #212121;
+	border-radius: 15px;
 }
 
 
@@ -160,18 +164,10 @@ img {
 
 /* responsive web design */
 
-.mobile {
-	display: none;
-}
-
 @media only screen and (max-width: 750px) {
-	.desktop {
-	    display: none;
-	}
-
-	.mobile {
-	    display: block;
-	}
+	.centre {
+        width: 100% !important;
+    }
 
 	ul {
 	    padding-left: 1.25em;


### PR DESCRIPTION
### what's changed:
- removed any css that didn't reference anything in the html file
- between the main content and the buttons at the bottom of the main landing page, removed the `.empty` `<div>` block and used a `margin-bottom` instead for separation
- made the small screen width/mobile layout work
  - *(you may adjust the padding on the sides by updating the value of the `.centre`'s `width` within the `@media only screen and (max-width: 750px)` block if you want)*
- used `background-image` for the background image instead of a `position: fixed` `<img>`
  - previously, the background image would move erratically on mobile layouts (specifically when the address bar/toolbar is hidden/shown) - using css `background-image` makes it smoother
  - however this *does* mean that the background image is now <1px higher than previously
    - *(though i'm pretty sure that meant that the previous implementation was <1px lower since i trust `background-position: center` centering the background image correctly)*